### PR TITLE
feat: allow phpunit 10

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -46,4 +46,4 @@ jobs:
       - name: Execute tests
         env:
           SYMFONY_DEPRECATIONS_HELPER: 'weak'
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "twilio/sdk": "^6.43"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.6 | ^10.0",
     "php-coveralls/php-coveralls": "^2.5"
   },
   "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
          bootstrap="Tests/bootstrap.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+
   <coverage>
     <include>
       <directory>./</directory>
     </include>
+
     <exclude>
       <directory>./Resources</directory>
       <directory>./Tests</directory>
       <directory>./vendor</directory>
     </exclude>
+
     <report>
       <clover outputFile="build/logs/clover.xml"/>
     </report>
   </coverage>
+
   <logging/>
+
   <testsuites>
     <testsuite name="BlackfordTwilioBundle Test Suite">
       <directory>./Tests</directory>
     </testsuite>
   </testsuites>
+
 </phpunit>


### PR DESCRIPTION
The argument `--verbose` is not supported anymore in phpUnit 10.
The removed parameters in phpunit.xml.dist are default values.