### PR TITLE
chore: add ci testruns for php 8.2 and 8.3

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -11,12 +11,19 @@ jobs:
       matrix:
         php: ['8.0']
         stability: [ prefer-lowest, prefer-stable ]
-        symfony-version: ['5.4', '6.0']
+        symfony-version: ['5.4', '6.3']
         experimental: [false]
         include:
           - php: '8.1'
             stability: prefer-stable
+            experimental: false
+          - php: '8.2'
+            stability: prefer-stable
+            experimental: false
+          - php: '8.3'
+            stability: prefer-stable
             experimental: true
+
     continue-on-error: ${{ matrix.experimental }}
 
     name: PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony-version }} - ${{ matrix.stability }} tests


### PR DESCRIPTION
change symfony test-version from 6.0 to 6.3