### PR TITLE
feat: allow symfony 7, ...

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         php: ['8.1']
         stability: [ prefer-stable ]
-        symfony-version: ['6.3']
+        symfony-version: ['6.4']
         experimental: [false]
         include:
           - php: '8.1'
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -27,6 +27,10 @@ jobs:
             stability: prefer-stable
             symfony-version: '7.0'
             experimental: true
+          - php: '8.4'
+            stability: prefer-stable
+            symfony-version: '7.0'
+            experimental: true
 
     continue-on-error: ${{ matrix.experimental }}
 

--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0']
-        stability: [ prefer-lowest, prefer-stable ]
-        symfony-version: ['5.4', '6.3']
+        php: ['8.1']
+        stability: [ prefer-stable ]
+        symfony-version: ['6.3']
         experimental: [false]
         include:
           - php: '8.1'
-            stability: prefer-stable
+            stability: prefer-lowest
             experimental: false
           - php: '8.2'
             stability: prefer-stable
@@ -23,13 +23,17 @@ jobs:
           - php: '8.3'
             stability: prefer-stable
             experimental: true
+          - php: '8.3'
+            stability: prefer-stable
+            symfony-version: '7.0'
+            experimental: true
 
     continue-on-error: ${{ matrix.experimental }}
 
     name: PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony-version }} - ${{ matrix.stability }} tests
     steps:
       # basically git clone
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 ---------
 
+## 7.0.0
+
+* Drop support of php 8.0
+* Drop support of symfony < 6.3
+* Drop support of Twilio PHP SDK version v6
+
 ## 6.0.0
 
 * Drop support of php 7

--- a/DependencyInjection/BlackfordTwilioExtension.php
+++ b/DependencyInjection/BlackfordTwilioExtension.php
@@ -1,7 +1,7 @@
 <?php
 namespace Blackford\TwilioBundle\DependencyInjection;
 
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Symfony Twilio Bundle (for Twilio SDK v6)
+# Symfony Twilio Bundle (for Twilio SDK v6+)
 
 # About
 
-A quick and easy way to use the Twilio SDK (version 6) in a Symfony based application.
-Support for PHP 8+, Symfony >= 5.4.
+A quick and easy way to use the Twilio SDK (version 7) in a Symfony based application.
+Support for PHP 8.1+, Symfony >= 6.3.
+Check older version of this repo, for supporting older Versions of PHP, Symfony, Twilio SDK.
 For full documentation about how to use the Twilio Client, see the [official SDK](https://github.com/twilio/twilio-php) provided by [Twilio](https://www.twilio.com/).
 
 This bundle is a small wrapper around the official sdk.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # About
 
 A quick and easy way to use the Twilio SDK (version 7) in a Symfony based application.
-Support for PHP 8.1+, Symfony >= 6.3.
+Support for PHP 8.1+, Symfony >= 6.4.
 Check older version of this repo, for supporting older Versions of PHP, Symfony, Twilio SDK.
 For full documentation about how to use the Twilio Client, see the [official SDK](https://github.com/twilio/twilio-php) provided by [Twilio](https://www.twilio.com/).
 
@@ -16,7 +16,7 @@ Thank you for the awesome work of [Fridolin Koch](http://fkse.io) who created th
 
 # Installation
 
-```
+```bash
 composer req blackford/twilio-bundle
 ```
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -3,8 +3,6 @@ namespace Blackford\TwilioBundle\Tests\DependencyInjection;
 
 use Blackford\TwilioBundle\DependencyInjection\Configuration;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Config\Definition\ArrayNode;
-use Symfony\Component\Config\Definition\ScalarNode;
 
 /**
  * Test the configuration tree

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
-    "symfony/framework-bundle": "^5.4 | ^6.0",
-    "twilio/sdk": "^6.43 | ^7.0"
+    "php": ">=8.1",
+    "symfony/framework-bundle": "^6.3 | ^7.0",
+    "twilio/sdk": "^7.12"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6 | ^10.0",
-    "php-coveralls/php-coveralls": "^2.5"
+    "phpunit/phpunit": "^10.4",
+    "php-coveralls/php-coveralls": "^2.6"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
   ],
   "require": {
     "php": ">=8.1",
-    "symfony/framework-bundle": "^6.3 | ^7.0",
-    "twilio/sdk": "^7.12"
+    "symfony/framework-bundle": "^6.4 | ^7.0",
+    "twilio/sdk": "^7.15"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.4",
-    "php-coveralls/php-coveralls": "^2.6"
+    "phpunit/phpunit": "^10.5 | ^11.0.3",
+    "php-coveralls/php-coveralls": "^2.7"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   "require": {
     "php": ">=8.1",
     "symfony/framework-bundle": "^6.4 | ^7.0",
-    "twilio/sdk": "^7.15"
+    "twilio/sdk": "^7.16.2 | ^8.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.5 | ^11.0.3",
+    "phpunit/phpunit": "^10.5 | ^11.1",
     "php-coveralls/php-coveralls": "^2.7"
   },
   "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,19 +2,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          colors="true"
          bootstrap="Tests/bootstrap.php"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
-
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
   <coverage>
-    <include>
-      <directory>./</directory>
-    </include>
-
-    <exclude>
-      <directory>./Resources</directory>
-      <directory>./Tests</directory>
-      <directory>./vendor</directory>
-    </exclude>
-
     <report>
       <clover outputFile="build/logs/clover.xml"/>
     </report>
@@ -27,5 +17,16 @@
       <directory>./Tests</directory>
     </testsuite>
   </testsuites>
+
+  <source>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Resources</directory>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </source>
 
 </phpunit>


### PR DESCRIPTION
Drop support of php 8.0,
Drop support of symfony < 6.3,
Drop support of Twilio PHP SDK version v6

The main goal is to allow symfony 7, and bump dependencies to lower maintenance cost.